### PR TITLE
Refactor internal representation of X and y

### DIFF
--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -1,8 +1,13 @@
 import inspect
+from typing import Union
+
+import numpy as np
+import pandas as pd
 from sklearn.base import ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
 
 from .gama import Gama
+from gama.data import X_y_from_arff
 from gama.configuration.classification import clf_config
 from gama.utilities.auto_ensemble import EnsembleClassifier
 
@@ -23,22 +28,33 @@ class GamaClassifier(Gama):
         self._label_encoder = None
         super().__init__(*args, **kwargs, config=config, scoring=scoring)
 
-    def predict(self, X=None, arff_file_path=None):
+    def _predict(self, x: pd.DataFrame):
         """ Predict the target for input X.
 
-        :param X: a 2d numpy array with the length of the second dimension is equal to that of X of `fit`.
+        :param x: a 2d numpy array with the length of the second dimension is equal to that of X of `fit`.
         :return: a numpy array with predictions. The array is of shape (N,) where N is the length of the
             first dimension of X.
         """
-        X = self._preprocess_predict_X(X, arff_file_path)
         classifier = self.ensemble if self._ensemble_fit else self._best_pipeline
-        y = classifier.predict(X)
+        y = classifier.predict(x)
         # Decode the predicted labels - necessary only if ensemble is not used.
         if y[0] not in self._label_encoder.classes_:
             y = self._label_encoder.inverse_transform(y)
         return y
 
-    def predict_proba(self, X=None, arff_file_path=None):
+    def _predict_proba(self, x: pd.DataFrame):
+        """ Predict the class probabilities for input x.
+
+        Predict target for x, using the best found pipeline(s) during the `fit` call.
+
+        :param x: a 2d numpy array with the length of the second dimension is equal to that of X of `fit`.
+        :return: a numpy array with class probabilities. The array is of shape (N, K) where N is the length of the
+            first dimension of X, and K is the number of class labels found in `y` of `fit`.
+        """
+        classifier = self.ensemble if self._ensemble_fit else self._best_pipeline
+        return classifier.predict_proba(x)
+
+    def predict_proba(self, X: Union[pd.DataFrame, np.ndarray]):
         """ Predict the class probabilities for input X.
 
         Predict target for X, using the best found pipeline(s) during the `fit` call.
@@ -47,9 +63,24 @@ class GamaClassifier(Gama):
         :return: a numpy array with class probabilities. The array is of shape (N, K) where N is the length of the
             first dimension of X, and K is the number of class labels found in `y` of `fit`.
         """
-        X = self._preprocess_predict_X(X, arff_file_path)
-        classifier = self.ensemble if self._ensemble_fit else self._best_pipeline
-        return classifier.predict_proba(X)
+        if isinstance(X, np.ndarray):
+            X = pd.DataFrame(X)
+            for col in self._X.columns:
+                X[col] = X[col].astype(self._X[col].dtype)
+        return self._predict_proba(X)
+
+    def predict_proba_arff(self, arff_file_path: str):
+        """ Predict the class probabilities for input in the arff_file, must have empty target column.
+
+        Predict target for X, using the best found pipeline(s) during the `fit` call.
+
+        :param arff_file_path: str
+
+        :return: a numpy array with class probabilities. The array is of shape (N, K) where N is the length of the
+            first dimension of X, and K is the number of class labels found in `y` of `fit`.
+        """
+        X, _ = X_y_from_arff(arff_file_path)
+        return self._predict_proba(X)
 
     def _encode_labels(self, y):
         self._label_encoder = LabelEncoder().fit(y)

--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -56,7 +56,7 @@ class GamaClassifier(Gama):
         return self._label_encoder.transform(y)
 
     def _initialize_ensemble(self):
-        self.ensemble = EnsembleClassifier(self._metrics[0], self.y_train,
+        self.ensemble = EnsembleClassifier(self._metrics[0], self._y,
                                            model_library_directory=self._cache_dir, n_jobs=self._n_jobs)
 
     def _build_fit_ensemble(self, ensemble_size, timeout):

--- a/gama/GamaRegressor.py
+++ b/gama/GamaRegressor.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from .gama import Gama
 from gama.configuration.regression import reg_config
 from gama.utilities.auto_ensemble import EnsembleRegressor
@@ -9,16 +11,15 @@ class GamaRegressor(Gama):
             config = reg_config
         super().__init__(*args, **kwargs, config=config, scoring=scoring)
 
-    def predict(self, X=None, arff_file_path=None):
+    def _predict(self, x: pd.DataFrame):
         """ Predict the target for input X.
 
-        :param X: a 2d numpy array with the length of the second dimension is equal to that of X of `fit`.
+        :param x: a 2d numpy array with the length of the second dimension is equal to that of X of `fit`.
         :return: a numpy array with predictions. The array is of shape (N,) where N is the length of the
             first dimension of X.
         """
-        X = self._preprocess_predict_X(X)
         regressor = self.ensemble if self._ensemble_fit else self._best_pipeline
-        return regressor.predict(X)
+        return regressor.predict(x)
 
     def _initialize_ensemble(self):
         self.ensemble = EnsembleRegressor(self._metrics[0], self._y,

--- a/gama/GamaRegressor.py
+++ b/gama/GamaRegressor.py
@@ -21,5 +21,5 @@ class GamaRegressor(Gama):
         return regressor.predict(X)
 
     def _initialize_ensemble(self):
-        self.ensemble = EnsembleRegressor(self._metrics[0], self.y_train,
+        self.ensemble = EnsembleRegressor(self._metrics[0], self._y,
                                           model_library_directory=self._cache_dir, n_jobs=self._n_jobs)

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -9,6 +9,7 @@ from functools import partial
 import sys
 import time
 import warnings
+from typing import Tuple, Callable
 
 import pandas as pd
 import numpy as np
@@ -151,12 +152,14 @@ class Gama(object):
         self._regularize_length = regularize_length
         self._time_manager = TimeKeeper(max_total_time)
         self._best_pipeline = None
-        self._fit_data = None
         self._observer = None
         self.ensemble = None
-        self._ensemble_fit = False
+        self._ensemble_fit: bool = False
         self._metrics = self._scoring_to_metric(scoring)
-        self._use_asha = False
+        self._use_asha: bool = False
+        self._X: pd.DataFrame = None
+        self._y: pd.Series = None
+        self._y_score = None
 
         default_cache_dir = datetime.datetime.now().strftime("%Y%m%d_%H%M%S") + "_GAMA"
         self._cache_dir = cache_dir if cache_dir is not None else default_cache_dir
@@ -206,8 +209,8 @@ class Gama(object):
             X, _ = X_y_from_arff(arff_file_path)
         elif isinstance(X, np.ndarray):
             X = pd.DataFrame(X)
-            for col in self.X.columns:
-                X[col] = X[col].astype(self.X[col].dtype)
+            for col in self._X.columns:
+                X[col] = X[col].astype(self._X[col].dtype)
         elif X is None:
             raise ValueError("Must specify either X or arff_file_path.")
 
@@ -224,19 +227,21 @@ class Gama(object):
         predictions = self.predict_proba(X) if self._metrics[0].requires_probabilities else self.predict(X)
         return self._metrics[0].score(y_score, predictions)
 
-    def _preprocess(self, X=None, y=None, arff_file_path=None):
-        if type(X) != type(y) and not (isinstance(X, pd.DataFrame) and isinstance(y, pd.Series)):
-            raise TypeError("X and y must be of the same type or respectively pd.DataFrame and pd.Series.")
-        if not isinstance(X, (type(None), np.ndarray, pd.DataFrame)):
-            raise TypeError("X must be either None, np.ndarray or pd.DataFrame.")
+    def _preprocess(self, X, y) -> Tuple[pd.DataFrame, pd.Series]:
+        if not isinstance(X, (np.ndarray, pd.DataFrame)):
+            raise TypeError("X must be either np.ndarray or pd.DataFrame.")
+        if not isinstance(y, (np.ndarray, pd.Series)):
+            raise TypeError("y must be either np.ndarray or pd.Series.")
 
         with self._time_manager.start_activity('preprocessing') as preprocessing_sw:
-            if arff_file_path is not None:
-                X, y = X_y_from_arff(arff_file_path)
-            elif isinstance(X, np.ndarray):
+            # Internally X is always a pd.DataFrame and y is always a pd.Series
+            if isinstance(X, np.ndarray):
                 X = heuristic_numpy_to_dataframe(X)
+            if hasattr(self, '_encode_labels'):
+                # This will return a numpy array
+                y = self._encode_labels(y)
+            if isinstance(y, np.ndarray):
                 y = pd.Series(y)
-            # else is already properly typed df/series
 
             if y.isnull().any():
                 log.info("Target vector has been found to contain NaN-labels, these rows will be ignored.")
@@ -245,13 +250,20 @@ class Gama(object):
             steps = define_preprocessing_steps(X, max_extra_features_created=None, max_categories_for_one_hot=10)
             self._operator_set._safe_compile = partial(compile_individual, preprocessing_steps=steps)
 
-            if hasattr(self, '_encode_labels'):
-                y = self._encode_labels(y)
-
         log_parseable_event(log, TOKENS.PREPROCESSING_END, preprocessing_sw.elapsed_time)
         return X, y
 
-    def fit(self, X=None, y=None, arff_file_path=None, warm_start=False, auto_ensemble_n=25, restart_=False, keep_cache=False):
+    def fit_arff(self, arff_file_path: str, *args, **kwargs):
+        """ Find and fit a model to predict the target column (last) from other columns.
+
+        :param arff_file_path: string
+            Path to an ARFF file containing the training data.
+            The last column is always taken to be the target.
+        """
+        X, y = X_y_from_arff(arff_file_path)
+        self.fit(X, y, *args, **kwargs)
+
+    def fit(self, X=None, y=None, warm_start=False, auto_ensemble_n=25, restart_=False, keep_cache=False):
         """ Find and fit a model to predict target y from X.
 
         Various possible machine learning pipelines will be fit to the (X,y) data.
@@ -261,15 +273,10 @@ class Gama(object):
         After the search termination condition is met, the best found pipeline
         configuration is then used to train a final model on all provided data.
 
-        Must either specify *both* `X` and `y`, or `arff_file_path`.
-
-        :param X: Numpy Array (optional), shape = [n_samples, n_features]
+        :param X: Numpy Array, shape = [n_samples, n_features]
             Training data. All elements must be able to be converted to float.
-        :param y: Numpy Array (optional), shape = [n_samples,]
+        :param y: Numpy Array, shape = [n_samples,]
             Target values.
-        :param arff_file_path: string (optional).
-            Path to an ARFF file containing the training data.
-            The last column is always taken to be the target.
         :param warm_start: bool. Indicates the optimization should continue using the last individuals of the
             previous `fit` call.
         :param auto_ensemble_n: positive integer. The number of models to include in the ensemble which is built
@@ -286,17 +293,13 @@ class Gama(object):
                 self._observer.reset_current_pareto_front()
             return restart and restart_
 
-        X, y = self._preprocess(X, y, arff_file_path)
-
-        self.X = X
-        self.y_train = y
-        self.y_score = self._construct_y_score(y)
-        self._fit_data = (X, y)
+        self._X, self._y = self._preprocess(X, y)
+        self._y_score = self._construct_y_score(y)
 
         fit_time = int((1 - ensemble_ratio) * self._time_manager.total_time_remaining)
 
         with self._time_manager.start_activity('search', time_limit=fit_time) as search_sw:
-            self._search_phase(X, y, warm_start, restart_criteria=restart_criteria, timeout=fit_time)
+            self._search_phase(warm_start, restart_criteria=restart_criteria, timeout=fit_time)
         log_parseable_event(log, TOKENS.SEARCH_END, search_sw.elapsed_time)
 
         with self._time_manager.start_activity('postprocess',
@@ -308,12 +311,12 @@ class Gama(object):
             log.debug("Deleting cache.")
             self.delete_cache()
 
-    def _construct_y_score(self, y):
+    def _construct_y_score(self, y: pd.Series):
         if any(metric.requires_probabilities for metric in self._metrics):
             return OneHotEncoder(categories='auto').fit_transform(y.reshape(-1, 1)).todense()
         return y
 
-    def _search_phase(self, X, y, warm_start=False, restart_criteria=None, timeout=1e6):
+    def _search_phase(self, warm_start: bool=False, restart_criteria: Callable=None, timeout: int=1e6):
         """ Invoke the evolutionary algorithm, populate `final_pop` regardless of termination. """
         if warm_start and self._final_pop is not None:
             pop = self._final_pop
@@ -322,7 +325,7 @@ class Gama(object):
                 log.warning('Warm-start enabled but no earlier fit. Using new generated population instead.')
             pop = [self._operator_set.individual() for _ in range(self._pop_size)]
 
-        evaluate_args = dict(evaluate_pipeline_length=self._regularize_length, X=self.X, y_train=self.y_train, y_score=self.y_score,
+        evaluate_args = dict(evaluate_pipeline_length=self._regularize_length, X=self._X, y_train=self._y, y_score=self._y_score,
                              timeout=self._max_eval_time, metrics=self._metrics, cache_dir=self._cache_dir)
         final_pop = []
 
@@ -337,7 +340,8 @@ class Gama(object):
                                          n_jobs=self._n_jobs)
                 else:
                     self._operator_set.evaluate = partial(evaluate_on_rung, **evaluate_args)
-                    final_pop = asha(self._operator_set, output=final_pop, start_candidates=pop, maximum_resource=len(X))
+                    final_pop = asha(self._operator_set, output=final_pop,
+                                     start_candidates=pop, maximum_resource=len(self._X))
                 log.debug([str(i) for i in self._final_pop])
         except KeyboardInterrupt:
             log.info('Search phase terminated because of Keyboard Interrupt.')
@@ -351,7 +355,7 @@ class Gama(object):
         log.info("Best pipeline has fitness of {}".format(self._best_individual.fitness.values))
         self._best_pipeline = self._best_individual.pipeline
         log.info("Pipeline {}, steps: {}".format(self._best_pipeline, self._best_pipeline.steps))
-        self._best_pipeline.fit(self.X, self.y_train)
+        self._best_pipeline.fit(self._X, self._y)
         if n > 1:
             self._build_fit_ensemble(n, timeout=timeout)
 
@@ -380,8 +384,7 @@ class Gama(object):
             timeout = timeout - build_time
             log.info('Building ensemble took {}s. Fitting ensemble with timeout {}s.'.format(build_time, timeout))
 
-            X, y = self._fit_data
-            self.ensemble.fit(X, y, timeout=timeout)
+            self.ensemble.fit(self._X, self._y, timeout=timeout)
             self._ensemble_fit = True
         except Exception as e:
             log.warning("Error during auto ensemble: {}".format(e))

--- a/gama/genetic_programming/algorithms/metrics.py
+++ b/gama/genetic_programming/algorithms/metrics.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import Callable
 
 import numpy as np
+import pandas as pd
 from sklearn import metrics
 
 """
@@ -78,9 +79,9 @@ class Metric:
         # Scikit-learn metrics can be very flexible with their input, interpreting a list as class labels for one
         # metric, while interpreting it as class probability for the positive class for another.
         # We want to force clear and early errors to avoid accidentally working with the wrong data/interpretation.
-        if not isinstance(y_true, np.ndarray):
+        if not isinstance(y_true, (np.ndarray, pd.Series)):
             raise TypeError('y_true must be a numpy array.')
-        if not isinstance(predictions, np.ndarray):
+        if not isinstance(predictions, (np.ndarray, pd.Series)):
             raise TypeError('predictions must be a numpy array.')
 
         required_dimensionality = 2 if self.requires_probabilities else 1

--- a/gama/utilities/auto_ensemble.py
+++ b/gama/utilities/auto_ensemble.py
@@ -248,10 +248,10 @@ class EnsembleClassifier(Ensemble):
         self._one_hot_encoder = OneHotEncoder(categories='auto').fit(y_as_squeezed_array)
 
         if self._metric.requires_probabilities:
-            self._y_score = self._one_hot_encoder.transform(y_as_squeezed_array).toarray()
+            self._y = self._one_hot_encoder.transform(y_as_squeezed_array).toarray()
         else:
             def one_hot_encode_predictions(predictions):
-                return self._one_hot_encoder.transform(predictions.values.reshape(-1, 1))
+                return self._one_hot_encoder.transform(predictions.reshape(-1, 1))
 
             self._prediction_transformation = one_hot_encode_predictions
 
@@ -260,11 +260,11 @@ class EnsembleClassifier(Ensemble):
             prediction_to_validate = self._averaged_validation_predictions()
 
         if self._metric.requires_probabilities:
-            return self._metric.maximizable_score(self._y_score, prediction_to_validate)
+            return self._metric.maximizable_score(self._y, prediction_to_validate)
         else:
             # argmax returns (N, 1) matrix, need to squeeze it to (N,) for scoring.
-            class_predictions = np.argmax(prediction_to_validate, axis=1).A.ravel()
-            return self._metric.maximizable_score(self._y_score, class_predictions)
+            class_predictions = np.argmax(prediction_to_validate.toarray(), axis=1)
+            return self._metric.maximizable_score(self._y, class_predictions)
 
     def predict(self, X):
         if self._metric.requires_probabilities:

--- a/gama/utilities/auto_ensemble.py
+++ b/gama/utilities/auto_ensemble.py
@@ -241,13 +241,13 @@ class EnsembleClassifier(Ensemble):
         self._label_encoder = label_encoder
 
         # For metrics that only require class labels, we still want to apply one-hot-encoding to average predictions.
-        self._one_hot_encoder = OneHotEncoder(categories='auto').fit(self._y_true.reshape(-1, 1))
+        self._one_hot_encoder = OneHotEncoder(categories='auto').fit(self._y_true.values.reshape(-1, 1))
 
         if self._metric.requires_probabilities:
-            self._y_score = self._one_hot_encoder.transform(self._y_true.reshape(-1, 1)).toarray()
+            self._y_score = self._one_hot_encoder.transform(self._y_true.values.reshape(-1, 1)).toarray()
         else:
             def one_hot_encode_predictions(predictions):
-                return self._one_hot_encoder.transform(predictions.reshape(-1, 1))
+                return self._one_hot_encoder.transform(predictions.values.reshape(-1, 1))
 
             self._prediction_transformation = one_hot_encode_predictions
 

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -1,7 +1,7 @@
 import category_encoders as ce
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import Imputer
+from sklearn.impute import SimpleImputer
 
 
 def define_preprocessing_steps(X_df, max_extra_features_created=None, max_categories_for_one_hot=10):
@@ -30,7 +30,7 @@ def define_preprocessing_steps(X_df, max_extra_features_created=None, max_catego
 
     one_hot_encoder = ce.OneHotEncoder(cols=one_hot_columns, handle_unknown='ignore')
     target_encoder = ce.TargetEncoder(cols=target_encoding_columns, handle_unknown='ignore')
-    imputer = Imputer(strategy='median')
+    imputer = SimpleImputer(strategy='median')
 
     return [one_hot_encoder, target_encoder, imputer]
 

--- a/tests/system/test_gamaclassifier.py
+++ b/tests/system/test_gamaclassifier.py
@@ -71,7 +71,7 @@ def _test_dataset_problem(data, metric, labelled_y=False, arff=False):
         y_test = [str(val) for val in y_test]
 
         with Stopwatch() as sw:
-            gama.fit(arff_file_path=train_path, auto_ensemble_n=5)
+            gama.fit_arff(train_path, auto_ensemble_n=5)
         class_predictions = gama.predict(arff_file_path=test_path)
         class_probabilities = gama.predict_proba(arff_file_path=test_path)
     else:

--- a/tests/system/test_gamaclassifier.py
+++ b/tests/system/test_gamaclassifier.py
@@ -1,6 +1,4 @@
 """ Contains full system tests for GamaClassifier """
-import unittest
-
 import numpy as np
 from sklearn.datasets import load_wine, load_breast_cancer
 from sklearn.model_selection import train_test_split
@@ -8,6 +6,9 @@ from sklearn.metrics import accuracy_score, log_loss
 
 from gama.utilities.generic.stopwatch import Stopwatch
 from gama import GamaClassifier
+
+import warnings
+warnings.filterwarnings("error")
 
 FIT_TIME_MARGIN = 1.1
 
@@ -72,8 +73,8 @@ def _test_dataset_problem(data, metric, labelled_y=False, arff=False):
 
         with Stopwatch() as sw:
             gama.fit_arff(train_path, auto_ensemble_n=5)
-        class_predictions = gama.predict(arff_file_path=test_path)
-        class_probabilities = gama.predict_proba(arff_file_path=test_path)
+        class_predictions = gama.predict_arff(test_path)
+        class_probabilities = gama.predict_proba_arff(test_path)
     else:
         X, y = data['load'](return_X_y=True)
         if labelled_y:


### PR DESCRIPTION
This patch streamlines the internal representation of `X` and `y` data.
 - Dedicated `_arff` functions for `fit`, `predict` and `score`.
 - Internally `X` will always be converted to `pandas.DataFrame` and `y` will be converted to `pandas.Series`.
 - Use of a separate `y_score` variable is dropped, conversion is now only applied where needed.
 - `train_data` is also dropped.
