### PR TITLE
Async

### DIFF
--- a/gama/gama.py
+++ b/gama/gama.py
@@ -1,14 +1,15 @@
 from abc import ABC
-import random
-import logging
-import os
 from collections import defaultdict
 import datetime
-import shutil
 from functools import partial
-import warnings
+import logging
+import os
+import random
+import shutil
+import time
 from typing import Union, Tuple, Optional, Dict
 import uuid
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -125,8 +126,8 @@ class Gama(ABC):
 
         if max_total_time is None or max_total_time <= 0:
             raise ValueError(f"max_total_time should be integer greater than zero but is {max_total_time}.")
-        if max_eval_time <= 0:
-            raise ValueError(f"max_eval_time should be integer greater than zero but is {max_eval_time}.")
+        if max_eval_time is not None and max_eval_time <= 0:
+            raise ValueError(f"max_eval_time should be None or integer greater than zero but is {max_eval_time}.")
         if n_jobs < -1 or n_jobs == 0:
             raise ValueError(f"n_jobs should be -1 or positive integer but is {n_jobs}.")
         elif n_jobs != -1:
@@ -322,8 +323,10 @@ class Gama(ABC):
                 log.warning('Warm-start enabled but no earlier fit. Using new generated population instead.')
             pop = [self._operator_set.individual() for _ in range(50)]
 
+        deadline = time.time() + timeout
         evaluate_args = dict(evaluate_pipeline_length=self._regularize_length, X=self._X, y_train=self._y,
-                             metrics=self._metrics, cache_dir=self._cache_dir, timeout=self._max_eval_time)
+                             metrics=self._metrics, cache_dir=self._cache_dir, timeout=self._max_eval_time,
+                             deadline=deadline)
         self._operator_set.evaluate = partial(gama.genetic_programming.compilers.scikitlearn.evaluate_individual,
                                               **evaluate_args)
 

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -132,6 +132,11 @@ class Gama(ABC):
             # AsyncExecutor defaults to using multiprocessing.cpu_count(), i.e. n_jobs=-1
             AsyncExecutor.n_jobs = n_jobs
 
+        if max_eval_time > max_total_time:
+            log.warning(f"max_eval_time ({max_eval_time}) > max_total_time ({max_total_time}) is not allowed. "
+                        f"max_eval_time set to {max_total_time}.")
+            max_eval_time = max_total_time
+
         self._random_state = random_state
         self._max_total_time = max_total_time
         self._max_eval_time = max_eval_time
@@ -317,7 +322,7 @@ class Gama(ABC):
             pop = [self._operator_set.individual() for _ in range(50)]
 
         evaluate_args = dict(evaluate_pipeline_length=self._regularize_length, X=self._X, y_train=self._y,
-                             timeout=self._max_eval_time, metrics=self._metrics, cache_dir=self._cache_dir)
+                             metrics=self._metrics, cache_dir=self._cache_dir, timeout=self._max_eval_time)
         self._operator_set.evaluate = partial(gama.genetic_programming.compilers.scikitlearn.evaluate_individual,
                                               **evaluate_args)
 

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -55,8 +55,8 @@ class Gama(ABC):
                  regularize_length: bool = True,
                  config: Dict = None,
                  random_state: int = None,
-                 max_total_time: Optional[int] = 3600,
-                 max_eval_time: Optional[int] = 300,
+                 max_total_time: int = 3600,
+                 max_eval_time: Optional[int] = None,
                  n_jobs: int = -1,
                  verbosity: int = logging.WARNING,
                  keep_analysis_log: Optional[str] = 'gama.log',
@@ -86,8 +86,9 @@ class Gama(ABC):
         max_total_time: positive int (default=3600)
             Time in seconds that can be used for the `fit` call.
 
-        max_eval_time: positive int, optional (default=300)
+        max_eval_time: positive int, optional (default=None)
             Time in seconds that can be used to evaluate any one single individual.
+            If None, set to 0.1 * max_total_time.
 
         n_jobs: int (default=-1)
             The amount of parallel processes that may be created to speed up `fit`.
@@ -124,7 +125,7 @@ class Gama(ABC):
 
         if max_total_time is None or max_total_time <= 0:
             raise ValueError(f"max_total_time should be integer greater than zero but is {max_total_time}.")
-        if max_eval_time is None or max_eval_time <= 0:
+        if max_eval_time <= 0:
             raise ValueError(f"max_eval_time should be integer greater than zero but is {max_eval_time}.")
         if n_jobs < -1 or n_jobs == 0:
             raise ValueError(f"n_jobs should be -1 or positive integer but is {n_jobs}.")
@@ -132,17 +133,18 @@ class Gama(ABC):
             # AsyncExecutor defaults to using multiprocessing.cpu_count(), i.e. n_jobs=-1
             AsyncExecutor.n_jobs = n_jobs
 
+        if max_eval_time is None:
+            max_eval_time = 0.1 * max_total_time
         if max_eval_time > max_total_time:
             log.warning(f"max_eval_time ({max_eval_time}) > max_total_time ({max_total_time}) is not allowed. "
                         f"max_eval_time set to {max_total_time}.")
             max_eval_time = max_total_time
 
-        self._random_state = random_state
-        self._max_total_time = max_total_time
         self._max_eval_time = max_eval_time
         self._time_manager = TimeKeeper(max_total_time)
         self._metrics: Tuple[Metric] = scoring_to_metric(scoring)
         self._regularize_length = regularize_length
+        self._search_method: BaseSearch = search_method
         self._post_processing = post_processing_method
 
         default_cache_dir = f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}_{str(uuid.uuid4())[:4]}_GAMA"
@@ -150,14 +152,13 @@ class Gama(ABC):
         if not os.path.isdir(self._cache_dir):
             os.mkdir(self._cache_dir)
 
-        if self._random_state is not None:
-            random.seed(self._random_state)
-            np.random.seed(self._random_state)
+        if random_state is not None:
+            random.seed(random_state)
+            np.random.seed(random_state)
 
         self._X: Optional[pd.DataFrame] = None
         self._y: Optional[pd.DataFrame] = None
         self.model: object = None
-        self._search_method: BaseSearch = search_method
         self._final_pop = None
 
         self._subscribers = defaultdict(list)

--- a/gama/genetic_programming/compilers/scikitlearn.py
+++ b/gama/genetic_programming/compilers/scikitlearn.py
@@ -1,10 +1,10 @@
+from datetime import datetime
 import logging
 import os
 import pickle
 import time
 from typing import Iterable
 import uuid
-from datetime import datetime
 
 import stopit
 from sklearn.preprocessing import OneHotEncoder
@@ -79,7 +79,7 @@ def evaluate_individual(individual: Individual, evaluate_pipeline_length, *args,
     return individual
 
 
-def evaluate_pipeline(pl, X, y_train, timeout, metrics='accuracy', cv=5, cache_dir=None, logger=None, subsample=None):
+def evaluate_pipeline(pl, X, y_train, timeout, deadline, metrics='accuracy', cv=5, cache_dir=None, logger=None, subsample=None):
     """ Evaluates a pipeline used k-Fold CV. """
     if not logger:
         logger = log
@@ -91,6 +91,9 @@ def evaluate_pipeline(pl, X, y_train, timeout, metrics='accuracy', cv=5, cache_d
     scores = tuple([float('-inf')] * len(metrics))
     start_datetime = datetime.now()
     start = time.process_time()
+
+    time_to_deadline = deadline - time.time()
+    timeout = min(timeout, time_to_deadline)
     with stopit.ThreadingTimeout(timeout) as c_mgr:
         try:
             if draw_subsample:

--- a/gama/search_methods/asha.py
+++ b/gama/search_methods/asha.py
@@ -1,7 +1,7 @@
 from functools import partial
 import logging
 import math
-from typing import List, Optional, Dict, Tuple, Any
+from typing import List, Optional, Dict, Tuple, Any, Callable
 
 import pandas as pd
 import stopit
@@ -61,7 +61,7 @@ class AsynchronousSuccessiveHalving(BaseSearch):
     def search(self, operations: OperatorSet, start_candidates: List[Individual]):
         hyperparameters = {parameter: set_value if set_value is not None else default
                            for parameter, (set_value, default) in self.hyperparameters.items()}
-        self.output = asha(operations, start_candidates=start_candidates, **hyperparameters)
+        self.output = asha(operations, start_candidates, **hyperparameters)
 
 
 def asha(operations: OperatorSet,
@@ -133,7 +133,7 @@ def asha(operations: OperatorSet,
                 time_penalty_for_rung = resource_for_rung[rung] / max(resource_for_rung.values())
                 futures.add(async_.submit(evaluate, individual, rung,
                                           subsample=resource_for_rung[rung],
-                                          timeout=min(10 + (time_penalty_for_rung * 600), 600)))
+                                          timeout=(10 + (time_penalty_for_rung * 600))))
 
             for _ in range(8):
                 start_new_job()

--- a/gama/search_methods/base_search.py
+++ b/gama/search_methods/base_search.py
@@ -1,10 +1,11 @@
 from abc import ABC
-from typing import List, Dict, Tuple, Any, Union
+from typing import List, Dict, Tuple, Any, Union, Callable
 
 import pandas as pd
 
 from gama.genetic_programming.operator_set import OperatorSet
 from gama.genetic_programming.components import Individual
+from gama.utilities.generic.timekeeper import TimeKeeper
 
 
 class BaseSearch(ABC):
@@ -47,7 +48,7 @@ class BaseSearch(ABC):
         ----------
         operations: OperatorSet
             Has methods to create new individuals, evaluate individuals and more.
-        start_candidates
+        start_candidates: List[Individual]
             A list of individuals to be considered before all others.
         """
         raise NotImplementedError("Must be implemented by child class.")

--- a/gama/search_methods/random_search.py
+++ b/gama/search_methods/random_search.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import List, Optional, Callable
 
 import pandas as pd
 

--- a/gama/utilities/generic/async_executor.py
+++ b/gama/utilities/generic/async_executor.py
@@ -28,13 +28,10 @@ class AsyncExecutor(concurrent.futures.ProcessPoolExecutor):
         self._futures = []
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        child_processes = list(self._processes.items())
-        self.shutdown(wait=False)
         for future in self._futures:
             if not future.done():
                 future.cancel()
-        for pid, process in child_processes:
-            process.terminate()
+        self.shutdown(wait=True)
         return False
 
     def submit(self, fn, *args, **kwargs):

--- a/gama/utilities/generic/timekeeper.py
+++ b/gama/utilities/generic/timekeeper.py
@@ -55,6 +55,16 @@ class TimeKeeper:
         else:
             raise RuntimeError("No activity in progress.")
 
+    @property
+    def current_activity_time_left(self) -> float:
+        """ Return time left in seconds of current activity. Raise RuntimeError if no current activity. """
+        if self.current_activity is not None and self.current_activity.time_limit is not None:
+            return self.current_activity.time_limit - self.current_activity.stopwatch.elapsed_time
+        elif self.current_activity is None:
+            raise RuntimeError("No activity in progress.")
+        else:
+            raise RuntimeError("No time limit set for current activity.")
+
     @contextmanager
     def start_activity(self,
                        activity: str,

--- a/tests/system/test_gamaregressor.py
+++ b/tests/system/test_gamaregressor.py
@@ -42,7 +42,7 @@ def _test_dataset_problem(data, metric):
     split_data = train_test_split(X, y, random_state=0)
 
     gama = GamaRegressor(random_state=0, max_total_time=TOTAL_TIME_S, scoring=metric, n_jobs=1, cache_dir=data['name'],
-                         post_processing_method=EnsemblePostProcessing(ensemble_size=5))
+                         max_eval_time=300, post_processing_method=EnsemblePostProcessing(ensemble_size=5))
     _test_gama_regressor(gama, *split_data, data, metric)
 
 

--- a/tests/unit/test_gama.py
+++ b/tests/unit/test_gama.py
@@ -26,11 +26,7 @@ def test_gama_fail_on_invalid_hyperparameter_values():
 
     with pytest.raises(ValueError) as e:
         gama.GamaClassifier(max_eval_time=0).delete_cache()
-    assert "max_eval_time should be integer greater than zero" in str(e.value)
-
-    with pytest.raises(ValueError) as e:
-        gama.GamaClassifier(max_eval_time=None).delete_cache()
-    assert "max_eval_time should be integer greater than zero" in str(e.value)
+    assert "max_eval_time should be None or integer greater than zero" in str(e.value)
 
     with pytest.raises(ValueError) as e:
         gama.GamaClassifier(n_jobs=-2).delete_cache()

--- a/tests/unit/test_scikitlearn.py
+++ b/tests/unit/test_scikitlearn.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import pandas as pd
 from sklearn.datasets import load_iris
@@ -63,6 +65,6 @@ def test_evaluate_pipeline(BernoulliNBStandardScaler):
     x, y = pd.DataFrame(x), pd.Series(y)
 
     scores, start, wallclock, process = evaluate_pipeline(
-        BernoulliNBStandardScaler.pipeline, x, y, timeout=60,
+        BernoulliNBStandardScaler.pipeline, x, y, timeout=60, deadline=time.time()+60,
         metrics=scoring_to_metric('accuracy'))
     assert 1 == len(scores)

--- a/tests/unit/test_utilities_generic_timekeeper.py
+++ b/tests/unit/test_utilities_generic_timekeeper.py
@@ -16,16 +16,28 @@ def test_timekeeper_total_time_remaning_error_if_total_time_zero():
 def test_timekeeper_stopwatch_normal_behavior():
     """ Ensure normal stopwatch functionality for stopwatch returned by context manager. """
     timekeeper = TimeKeeper()
-    with timekeeper.start_activity('test activity') as sw:
+    with timekeeper.start_activity('test activity', time_limit=3) as sw:
         assert pytest.approx(0, abs=ROUND_ERROR) == sw.elapsed_time
+        assert pytest.approx(0, abs=ROUND_ERROR) == timekeeper.current_activity_time_elapsed
         assert sw._is_running
+        assert pytest.approx(3, abs=ROUND_ERROR) == timekeeper.current_activity_time_left
         time.sleep(1)
         assert pytest.approx(1, abs=ROUND_ERROR) == sw.elapsed_time
+        assert pytest.approx(1, abs=ROUND_ERROR) == timekeeper.current_activity_time_elapsed
+        assert pytest.approx(2, abs=ROUND_ERROR) == timekeeper.current_activity_time_left
         assert sw._is_running
 
     time.sleep(1)
     assert not sw._is_running
     assert pytest.approx(1, abs=ROUND_ERROR) == sw.elapsed_time
+
+    with pytest.raises(RuntimeError) as error:
+        timekeeper.current_activity_time_elapsed
+    assert "No activity in progress." in str(error.value)
+
+    with pytest.raises(RuntimeError) as error:
+        timekeeper.current_activity_time_left
+    assert "No activity in progress." in str(error.value)
 
 
 def test_timekeeper_total_remaining_time():


### PR DESCRIPTION
Instead of terminating subprocesses used for evaluating pipelines at the end of the search phase, close them properly. Avoid subprocesses running over time by adjusting the `timeout` value to never exceed the end of the search phase. In theory, I think subprocesses could still exceed the `timeout` if underlying non-Python code is being ran. In integration tests it behaves nicely so far, however.