### PR TITLE
Small update

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -4,6 +4,9 @@ Release Notes
 
 Version 19.11.3
 ---------------
+Bugfixes:
+ #68: Only add categorical encoding steps if (non-binary) categorical data is present.
+
 Maintenance:
  #67: Selection now takes crowding distance into account (again).
  #68: `n_jobs` will now default to use half of available cores.

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -5,7 +5,9 @@ Release Notes
 Version 19.11.3
 ---------------
 Maintenance:
- - Selection now takes crowding distance into account (again).
+ #67: Selection now takes crowding distance into account (again).
+ #68: `n_jobs` will now default to use half of available cores.
+ #68: Updates given about the Pareto front now include the pipeline structure.
 
 
 Version 19.11.2

--- a/gama/utilities/observer.py
+++ b/gama/utilities/observer.py
@@ -31,7 +31,7 @@ class Observer(object):
                          str(ind)]
             fh.write(';'.join(to_record) + '\n')
 
-    def update(self, ind):
+    def update(self, ind: Individual):
         log.debug("Evaluation;{:.4f};{};{}".format(ind.fitness.wallclock_time, ind.fitness.values, ind))
         self._individuals.append(ind)
         if self._with_log:
@@ -40,7 +40,7 @@ class Observer(object):
         updated = self._current_pareto_front.update(ind)
         if updated:
             self._individuals_since_last_pareto_update = 0
-            log.info("Current pareto-front updated with individual with wvalues {}.".format(ind.fitness.values))
+            log.info("Current Pareto front updated: {} scores {}".format(ind.short_name, ind.fitness.values))
         else:
             self._individuals_since_last_pareto_update += 1
 

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -45,11 +45,15 @@ def define_preprocessing_steps(X_df: pd.DataFrame,
             else:
                 pass  # Binary category or constant feature.
 
-    one_hot_encoder = ce.OneHotEncoder(cols=one_hot_columns, handle_unknown='ignore')
-    target_encoder = ce.TargetEncoder(cols=target_encoding_columns, handle_unknown='ignore')
-    imputer = SimpleImputer(strategy='median')
-
-    return [one_hot_encoder, target_encoder, imputer]
+    steps = []
+    if one_hot_columns != []:
+        steps.append(ce.OneHotEncoder(cols=one_hot_columns, handle_unknown='ignore'))
+    if target_encoding_columns != []:
+        steps.append(ce.TargetEncoder(cols=target_encoding_columns, handle_unknown='ignore'))
+    # We always train an Imputer so we can impute missing data in the test set even if training data
+    # has no missing values. It would be better to only do this for the final pipeline.
+    steps.append(SimpleImputer(strategy='median'))
+    return steps
 
 
 def heuristic_numpy_to_dataframe(X: np.ndarray, max_unique_values_cat: int = 10) -> pd.DataFrame:


### PR DESCRIPTION
Bugfixes:
 #68: Only add categorical encoding steps if (non-binary) categorical data is present.

Maintenance:
 #68: `n_jobs` will now default to use half of available cores.
 #68: Updates given about the Pareto front now include the pipeline structure.