### PR TITLE
Minorfixes

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Version 20.0.1
+--------------
+Bugfixes:
+ - Reading ARFF markers (such as @data and @attribute) is now correctly case insensitive.
+
 Version 20.0.0
 --------------
 Features:

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -3,6 +3,9 @@ Release Notes
 
 Version 20.0.1
 --------------
+Features:
+ - Encoding of ARFF files may now be specified with the `encoding` parameter in {fit/predict/score}_arff calls.
+
 Bugfixes:
  - Reading ARFF markers (such as @data and @attribute) is now correctly case insensitive.
 

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,13 +1,18 @@
 Release Notes
 =============
 
-Version 20.0.1
+Version 20.1.0
 --------------
 Features:
  - Encoding of ARFF files may now be specified with the `encoding` parameter in {fit/predict/score}_arff calls.
 
 Bugfixes:
  - Reading ARFF markers (such as @data and @attribute) is now correctly case insensitive.
+
+Changes:
+ - Pipelines fitted during search are now used in the ensemble, instead of retraining the pipeline.
+ - Ordinal Encoding and One Hot Encoding are now applied outside of 5-fold CV.
+   This is for computational reasons, as all levels of a categorical variable are known this shouldn't make a difference.
 
 Version 20.0.0
 --------------

--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -82,10 +82,7 @@ class GamaClassifier(Gama):
             Array of shape (N, K) with class probabilities where N is the length of the
             first dimension of x, and K is the number of class labels found in `y` of `fit`.
         """
-        if isinstance(x, np.ndarray):
-            x = pd.DataFrame(x)
-            for col in self._X.columns:
-                x[col] = x[col].astype(self._X[col].dtype)
+        x = self._prepare_for_prediction(x)
         return self._predict_proba(x)
 
     def predict_proba_arff(self,
@@ -111,8 +108,9 @@ class GamaClassifier(Gama):
             Numpy array with class probabilities. The array is of shape (N, K) where N is the length of the
             first dimension of X, and K is the number of class labels found in `y` of `fit`.
         """
-        X, _ = X_y_from_arff(arff_file_path, target_column, encoding)
-        return self._predict_proba(X)
+        x, _ = X_y_from_arff(arff_file_path, target_column, encoding)
+        x = self._prepare_for_prediction(x)
+        return self._predict_proba(x)
 
     def fit(self, x, y, *args, **kwargs):
         """ Should use base class documentation. """

--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -88,7 +88,10 @@ class GamaClassifier(Gama):
                 x[col] = x[col].astype(self._X[col].dtype)
         return self._predict_proba(x)
 
-    def predict_proba_arff(self, arff_file_path: str, target_column: Optional[str] = None):
+    def predict_proba_arff(self,
+                           arff_file_path: str,
+                           target_column: Optional[str] = None,
+                           encoding: Optional[str] = None):
         """ Predict the class probabilities for input in the arff_file, must have empty target column.
 
         Parameters
@@ -99,6 +102,8 @@ class GamaClassifier(Gama):
         target_column: str, optional (default=None)
             Specifies which column the model should predict.
             If left None, the last column is taken to be the target.
+        encoding: str, optional
+            Encoding of the ARFF file.
 
         Returns
         -------
@@ -106,7 +111,7 @@ class GamaClassifier(Gama):
             Numpy array with class probabilities. The array is of shape (N, K) where N is the length of the
             first dimension of X, and K is the number of class labels found in `y` of `fit`.
         """
-        X, _ = X_y_from_arff(arff_file_path, target_column)
+        X, _ = X_y_from_arff(arff_file_path, target_column, encoding)
         return self._predict_proba(X)
 
     def fit(self, x, y, *args, **kwargs):

--- a/gama/data.py
+++ b/gama/data.py
@@ -5,13 +5,15 @@ import arff
 import pandas as pd
 
 
-def arff_to_pandas(file_path: str) -> pd.DataFrame:
+def arff_to_pandas(file_path: str, encoding: Optional[str] = None) -> pd.DataFrame:
     """ Load data from the ARFF file into a pd.DataFrame.
 
     Parameters
     ----------
     file_path: str
         Path of the ARFF file
+    encoding: str, optional
+        Encoding of the ARFF file.
 
     Returns
     -------
@@ -22,7 +24,7 @@ def arff_to_pandas(file_path: str) -> pd.DataFrame:
     if not isinstance(file_path, str):
         raise TypeError(f"`file_path` must be of type `str` but is of type {type(file_path)}")
 
-    with open(file_path, 'r') as arff_file:
+    with open(file_path, 'r', encoding=encoding) as arff_file:
         arff_dict = arff.load(arff_file)
 
     attribute_names, data_types = zip(*arff_dict['attributes'])
@@ -34,7 +36,7 @@ def arff_to_pandas(file_path: str) -> pd.DataFrame:
     return data
 
 
-def X_y_from_arff(file_path: str, split_column: Optional[str] = None) -> Tuple[pd.DataFrame, pd.Series]:
+def X_y_from_arff(file_path: str, split_column: Optional[str] = None, encoding: Optional[str] = None) -> Tuple[pd.DataFrame, pd.Series]:
     """ Load data from the ARFF file into pandas DataFrame and specified column to pd.Series. "
 
     Parameters
@@ -45,13 +47,15 @@ def X_y_from_arff(file_path: str, split_column: Optional[str] = None) -> Tuple[p
         Column to split and return separately (e.g. target column).
         Value should either match a column name or None.
         If None is specified, the last column is returned separately.
+    encoding: str, optional
+        Encoding of the ARFF file.
 
     Returns
     -------
     Tuple[pd.DataFrame, pd.Series]
         Features (everything except split_column) and targets (split_column).
     """
-    data = arff_to_pandas(file_path)
+    data = arff_to_pandas(file_path, encoding)
 
     if split_column is None:
         return data.iloc[:, :-1], data.iloc[:, -1]

--- a/gama/data.py
+++ b/gama/data.py
@@ -63,13 +63,13 @@ def X_y_from_arff(file_path: str, split_column: Optional[str] = None) -> Tuple[p
 
 def load_feature_metadata_from_arff(file_path: str) -> Dict[str, str]:
     """ Load the header of the ARFF file and return the type of each attribute. """
-    data_header = '@DATA'
-    attribute_indicator = '@ATTRIBUTE'
+    data_header = '@data'
+    attribute_indicator = '@attribute'
     attributes = {}
     with open(file_path, 'r') as fh:
         line = fh.readline()
-        while not line.startswith(data_header):
-            if line.startswith(attribute_indicator):
+        while not line.lower().startswith(data_header):
+            if line.lower().startswith(attribute_indicator):
                 # arff uses a space separator, but allows spaces in
                 # feature name (name must be quoted) and feature type (if nominal).
                 indicator, name_and_type = line.split(' ', 1)

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -208,7 +208,10 @@ class Gama(ABC):
                 x[col] = x[col].astype(self._X[col].dtype)
         return self._predict(x)
 
-    def predict_arff(self, arff_file_path: str, target_column: Optional[str] = None) -> np.ndarray:
+    def predict_arff(self,
+                     arff_file_path: str,
+                     target_column: Optional[str] = None,
+                     encoding: Optional[str] = None) -> np.ndarray:
         """ Predict the target for input found in the ARFF file.
 
         Parameters
@@ -219,13 +222,15 @@ class Gama(ABC):
         target_column: str, optional (default=None)
             Specifies which column the model should predict.
             If left None, the last column is taken to be the target.
+        encoding: str, optional
+            Encoding of the ARFF file.
 
         Returns
         -------
         numpy.ndarray
             array with predictions for each row in the ARFF file.
         """
-        X, _ = X_y_from_arff(arff_file_path, split_column=target_column)
+        X, _ = X_y_from_arff(arff_file_path, split_column=target_column, encoding=encoding)
         return self._predict(X)
 
     def score(self, x: Union[pd.DataFrame, np.ndarray], y: Union[pd.Series, np.ndarray]) -> float:
@@ -246,7 +251,11 @@ class Gama(ABC):
         predictions = self.predict_proba(x) if self._metrics[0].requires_probabilities else self.predict(x)
         return self._metrics[0].score(y, predictions)
 
-    def score_arff(self, arff_file_path: str, target_column: Optional[str] = None) -> float:
+    def score_arff(self,
+                   arff_file_path: str,
+                   target_column: Optional[str] = None,
+                   encoding: Optional[str] = None
+                   ) -> float:
         """ Calculate the score of the model according to the `scoring` metric and input in the ARFF file.
 
         Parameters
@@ -256,16 +265,23 @@ class Gama(ABC):
         target_column: str, optional (default=None)
             Specifies which column the model should predict.
             If left None, the last column is taken to be the target.
+        encoding: str, optional
+            Encoding of the ARFF file.
 
         Returns
         -------
         float
             The score obtained on the given test data according to the `scoring` metric.
         """
-        X, y = X_y_from_arff(arff_file_path, split_column=target_column)
+        X, y = X_y_from_arff(arff_file_path, split_column=target_column, encoding=encoding)
         return self.score(X, y)
 
-    def fit_arff(self, arff_file_path: str, target_column: Optional[str] = None, *args, **kwargs):
+    def fit_arff(self,
+                 arff_file_path: str,
+                 target_column: Optional[str] = None,
+                 encoding: Optional[str] = None,
+                 *args, **kwargs
+                 ) -> None:
         """ Find and fit a model to predict the target column (last) from other columns.
 
         Parameters
@@ -275,16 +291,18 @@ class Gama(ABC):
         target_column: str, optional (default=None)
             Specifies which column the model should predict.
             If left None, the last column is taken to be the target.
+        encoding: str, optional
+            Encoding of the ARFF file.
 
         """
-        X, y = X_y_from_arff(arff_file_path, split_column=target_column)
+        X, y = X_y_from_arff(arff_file_path, split_column=target_column, encoding=encoding)
         self.fit(X, y, *args, **kwargs)
 
     def fit(self,
             x: Union[pd.DataFrame, np.ndarray],
             y: Union[pd.DataFrame, pd.Series, np.ndarray],
             warm_start: bool = False,
-            keep_cache: bool = False):
+            keep_cache: bool = False) -> None:
         """ Find and fit a model to predict target y from X.
 
         Various possible machine learning pipelines will be fit to the (X,y) data.

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -1,11 +1,63 @@
 import logging
-from typing import Tuple, Union, Type, Optional
+from typing import Optional, Iterator
 import category_encoders as ce
 import numpy as np
 import pandas as pd
 from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
 
 log = logging.getLogger(__name__)
+
+
+def find_categorical_columns(
+        df: pd.DataFrame,
+        min_f: Optional[int] = None,
+        max_f: Optional[int] = None,
+        ignore_nan: bool = True
+) -> Iterator[str]:
+    """ Find all categorical columns with at least `min_f` and at most `max_f` factors.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Pandas DataFrame to design the encoder for.
+    min_f: int, optional (default=None)
+        The inclusive minimum number of unique values the column should have to be encoded with the given scheme.
+    max_f: int, optional (default=None)
+        The inclusive maximum number of unique values the column should have to be encoded with the given scheme.
+    ignore_nan: bool (default=True)
+        If True, don't count NaN as a unique value. If False, count NaN as a unique value (only once).
+
+    Returns
+    -------
+    An iterator which iterates over the column names that satisfy the criteria.
+    """
+    for column in df:
+        if isinstance(df[column].dtype, pd.core.dtypes.dtypes.CategoricalDtype):
+            nfactors = df[column].nunique(dropna=ignore_nan)
+            if (min_f is None or min_f <= nfactors) and (max_f is None or nfactors <= max_f):
+                yield column
+
+
+def basic_encoding(x: pd.DataFrame):
+    """ Performs 'basic' encoding of categorical features. Ordinal if 2 or fewer unique values, OHE if at most 10. """
+    binary_features = list(find_categorical_columns(x, max_f=2))
+    few_factor_features = list(find_categorical_columns(x, min_f=3, max_f=10))
+
+    encoding_pipeline = Pipeline(
+        steps=[
+            ('ord-enc', ce.OrdinalEncoder(cols=binary_features, drop_invariant=True)),
+            ('oh-enc', ce.OneHotEncoder(cols=few_factor_features, handle_missing='ignore'))
+        ]
+    )
+    x_enc = encoding_pipeline.fit_transform(x, y=None)  # Is this allowed?
+    return x_enc, encoding_pipeline
+
+
+def basic_pipeline_extension(x: pd.DataFrame):
+    """ Defines a TargetEncoder for categorical features with more than 10 unique values, and an imputation step. """
+    many_factor_features = list(find_categorical_columns(x, min_f=11))
+    return [ce.TargetEncoder(cols=many_factor_features), SimpleImputer(strategy='median')]
 
 
 def define_preprocessing_steps(X_df: pd.DataFrame,
@@ -36,83 +88,41 @@ def define_preprocessing_steps(X_df: pd.DataFrame,
 
     one_hot_columns = []
     target_encoding_columns = []
+    ordinal_encoding_columns = []
     for unique_values, dtype, column_index in zip(X_df.apply(pd.Series.nunique), X_df.dtypes, X_df.columns):
         if isinstance(dtype, pd.core.dtypes.dtypes.CategoricalDtype):
             if unique_values > max_categories_for_one_hot:
                 target_encoding_columns.append(column_index)
-            elif unique_values > 1:
-                one_hot_columns.append(column_index)
+            elif unique_values < 2:
+                # Either a constant feature (which gets dropped),
+                # or a feature with one unique value and NaNs, where we will encode NaN as a value
+                ordinal_encoding_columns.append(column_index)
+            elif unique_values == 2:
+                if X_df[column_index].isnull().any():
+                    # Two unique values and at least one missing value, we apply OHE.
+                    one_hot_columns.append(column_index)
+                elif X_df[column_index].dtype.categories.dtype == np.dtype('O'):
+                    # Even with just two unique values, we need to still map str to numeric for sklearn friendliness.
+                    ordinal_encoding_columns.append(column_index)
+                else:
+                    # 2 unique values, but has a missing value or is numeric already, move on to next column
+                    continue
             else:
-                pass  # Binary category or constant feature.
+                one_hot_columns.append(column_index)
 
+    log.debug(f"Detected {sum(isinstance(dtype, pd.core.dtypes.dtypes.CategoricalDtype) for dtype in X_df.dtypes)} categorical variables, of which:"
+              f" - {len(one_hot_columns)} are encoded with OneHotEncoding"
+              f" - {len(ordinal_encoding_columns)} are encoded with OrdinalEncoding"
+              f" - {len(target_encoding_columns)} are encoded with TargetEncoding.")
     steps = []
-    if one_hot_columns != []:
-        steps.append(ce.OneHotEncoder(cols=one_hot_columns, handle_unknown='ignore'))
-    if target_encoding_columns != []:
-        steps.append(ce.TargetEncoder(cols=target_encoding_columns, handle_unknown='ignore'))
+    if ordinal_encoding_columns:
+        steps.append(ce.OrdinalEncoder(cols=ordinal_encoding_columns, drop_invariant=True, handle_missing='value'))
+    if one_hot_columns:
+        steps.append(ce.OneHotEncoder(cols=one_hot_columns, handle_missing='return_nan'))
+    if target_encoding_columns:
+        steps.append(ce.TargetEncoder(cols=target_encoding_columns, handle_missing='value'))
+
     # We always train an Imputer so we can impute missing data in the test set even if training data
     # has no missing values. It would be better to only do this for the final pipeline.
     steps.append(SimpleImputer(strategy='median'))
     return steps
-
-
-def heuristic_numpy_to_dataframe(X: np.ndarray, max_unique_values_cat: int = 10) -> pd.DataFrame:
-    """ Transform a numpy array to a typed pd.DataFrame. """
-    X_df = pd.DataFrame(X)
-    for column, n_unique in X_df.nunique(dropna=True).items():
-        if n_unique <= max_unique_values_cat:
-            X_df[column] = X_df[column].astype('category')
-    return X_df
-
-
-def format_x_y(x: Union[pd.DataFrame, np.ndarray], y: Union[pd.DataFrame, pd.Series, np.ndarray],
-               y_type: Type=pd.Series, remove_unlabeled: bool = True
-               ) -> Tuple[pd.DataFrame, Union[pd.DataFrame, pd.Series]]:
-    """ Takes various types of (X,y) data and converts it into a (pd.DataFrame, pd.Series) tuple.
-
-    Parameters
-    ----------
-    x: pandas.DataFrame or numpy.ndarray
-    y: pandas.DataFrame, pandas.Series or numpy.ndarray
-    y_type: Type (default=pandas.Series)
-    remove_unlabeled: bool (default=True)
-        If true, remove all rows associated with unlabeled data (NaN in y).
-
-    Returns
-    -------
-    Tuple[pandas.DataFrame, pandas.DataFrame or pandas.Series]
-        X and y, where X is formatted as pd.DataFrame and y is formatted as `y_type`.
-    """
-    if not isinstance(x, (np.ndarray, pd.DataFrame)):
-        raise TypeError("X must be either np.ndarray or pd.DataFrame.")
-    if not isinstance(y, (np.ndarray, pd.Series, pd.DataFrame)):
-        raise TypeError("y must be np.ndarray, pd.Series or pd.DataFrame.")
-
-    if isinstance(x, np.ndarray):
-        x = heuristic_numpy_to_dataframe(x)
-    if isinstance(y, np.ndarray) and y.ndim == 2:
-        # Either indicator matrix or should be a vector.
-        if y.shape[1] > 1:
-            y = np.argmax(y, axis=1)
-        else:
-            y = y.squeeze()
-
-    if y_type == pd.Series:
-        if isinstance(y, pd.DataFrame):
-            y = y.squeeze()
-        elif isinstance(y, np.ndarray):
-            y = pd.Series(y)
-    elif y_type == pd.DataFrame:
-        if not isinstance(y, pd.DataFrame):
-            y = pd.DataFrame(y)
-    else:
-        raise ValueError(f"`y_type` must be one of [pandas.Series, pandas.DataFrame] but is {y_type}.")
-
-    if remove_unlabeled:
-        unlabeled = y[y.columns[0]].isnull() if isinstance(y, pd.DataFrame) else y.isnull()
-        if unlabeled.any():
-            log.info(f"Target vector has been found to contain {sum(unlabeled)} NaN-labels, "
-                     f"these rows will be ignored.")
-            x, y = x.loc[~unlabeled], y.loc[~unlabeled]
-
-    return x, y

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1,6 +1,6 @@
 import itertools
 import pandas as pd
-from gama.utilities.preprocessing import format_x_y
+from gama.data import format_x_y
 
 
 def test_format_x_y():

--- a/tests/unit/test_scikitlearn.py
+++ b/tests/unit/test_scikitlearn.py
@@ -20,11 +20,12 @@ def test_cross_val_predict_score():
     x, y = pd.DataFrame(x), pd.Series(y)
 
     metrics = scoring_to_metric(['accuracy', 'log_loss'])
-    predictions, scores = cross_val_predict_score(estimator, x, y, metrics=metrics)
+    predictions, scores, estimators = cross_val_predict_score(estimator, x, y, metrics=metrics)
     accuracy, logloss = scores
 
     assert accuracy_score(y_ohe, predictions) == pytest.approx(accuracy)
     assert -1 * log_loss(y_ohe, predictions) == pytest.approx(logloss)
+    assert len(set(estimators)) == len(estimators)
 
 
 def test_evaluate_individual(BernoulliNBStandardScaler, mocker):


### PR DESCRIPTION
Features:
 - Encoding of ARFF files may now be specified with the `encoding` parameter in {fit/predict/score}_arff calls.

Bugfixes:
 - Reading ARFF markers (such as `@data` and `@attribute`) is now correctly case insensitive.

Changes:
 - Pipelines fitted during search are now used in the ensemble, instead of retraining the pipeline.
 - Ordinal Encoding and One Hot Encoding are now applied outside of 5-fold CV.
   This is for computational reasons, as all levels of a categorical variable are known this shouldn't make a difference.